### PR TITLE
Add extra compile command in readme for Mac/Linux

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,15 @@ Allows dumping very early 3DS ROFS containers.
 
 ## Compiling
 
+Add `-static` if static linking is needed
+
+### Windows
+
 `g++ -std=c++20 main.cpp -o rofs_dump.exe`
-(Add `-static` if static linking is needed)
+
+### MacOS / Linux
+
+`g++ -std=c++20 main.cpp -o rofs_dump`
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Add `-static` if static linking is needed
 
 ## Usage
 
-`rofs_dump.exe (in_file) (out_dir)`
+`rofs_dump (in_file) (out_dir)`
 
 ## License
 


### PR DESCRIPTION
This is just to make sure it's as clear as possible to the user, since only releases for Windows are available.